### PR TITLE
Fixing to match return type from function_to_json

### DIFF
--- a/swarm/core.py
+++ b/swarm/core.py
@@ -49,10 +49,10 @@ class Swarm:
         tools = [function_to_json(f) for f in assistant.functions]
         # hide context_variables from model
         for tool in tools:
-            props = tool["function"]["parameters"]["properties"]
-            props.pop(__CTX_VARS_NAME__, None)
-            if __CTX_VARS_NAME__ in props["required"]:
-                props["required"].remove(__CTX_VARS_NAME__)
+            params = tool["function"]["parameters"]
+            params["properties"].pop(__CTX_VARS_NAME__, None)
+            if __CTX_VARS_NAME__ in params["required"]:
+                params["required"].remove(__CTX_VARS_NAME__)
 
         return self.client.chat.completions.create(
             model=model_override or assistant.model,


### PR DESCRIPTION
    return {
        "type": "function",
        "function": {
            "name": func.__name__,
            "description": func.__doc__ or "",
            "parameters": {
                "type": "object",
                "properties": parameters,
                "required": required,
            },
        },
    }
    