### PR TITLE
Make Result.assistant --> Optional[Assistant]

### DIFF
--- a/swarm/core.py
+++ b/swarm/core.py
@@ -244,7 +244,7 @@ class Swarm:
         history = copy.deepcopy(messages)
         init_len = len(messages)
 
-        while len(history) - init_len < max_turns:
+        while len(history) - init_len < max_turns and active_assistant:
 
             # get completion with current history, assistant
             completion = self.get_chat_completion(
@@ -270,8 +270,7 @@ class Swarm:
             )
             history.extend(partial_response.messages)
             context_variables.update(partial_response.context_variables)
-            if partial_response.assistant:
-                active_assistant = partial_response.assistant
+            active_assistant = partial_response.assistant
 
         return Response(
             messages=history[init_len:],

--- a/swarm/types.py
+++ b/swarm/types.py
@@ -36,5 +36,5 @@ class Result(BaseModel):
     """
 
     value: str = ""
-    assistant: Assistant = None
+    assistant: Optional[Assistant] = None
     context_variables: dict = {}


### PR DESCRIPTION
###### Why/Context/Summary

Currently the `Result.assistant` field is non-optional but is set to `None` by default.  The logic indicates that `None` is valid.  However, setting it to `None` results in pydantic complaining about it.

###### Test plan

Tested locally