### PR TITLE
Add post_execute call

### DIFF
--- a/examples/airline/evals/eval_utils.py
+++ b/examples/airline/evals/eval_utils.py
@@ -83,8 +83,6 @@ def run_function_evals(assistant, test_cases, n=1, eval_path=None):
 
     return overall_accuracy
 
-    return overall_accuracy
-
 
 def extract_response_info(response):
     results = {}

--- a/swarm.egg-info/PKG-INFO
+++ b/swarm.egg-info/PKG-INFO
@@ -323,7 +323,7 @@ class Response(BaseModel):
 def run(
    assistant: Assistant,
    messages: List,
-   context: dict = {},
+   context: dict = None,
    model_override: str = None,
    debug: bool = False,
    max_turns: int = float("inf"),

--- a/swarm/assistants/assistants.py
+++ b/swarm/assistants/assistants.py
@@ -9,9 +9,11 @@ def create_triage_assistant(
             "Determine which assistant is best suited to handle the user's request, "
             "and transfer the conversation to that assistant."
         ),
-        assistants: List[Assistant] = [],
+        assistants: List[Assistant] = None,
         add_backlinks: bool = True,
 ) -> Assistant:
+    assistants = assistants or []
+
     def transfer_back_to_triage() -> Assistant:
         """Only call this function if a user is asking about a topic that is not handled by the current assistant."""
         return ta

--- a/swarm/core.py
+++ b/swarm/core.py
@@ -130,7 +130,7 @@ class Swarm:
         self,
         assistant: Assistant,
         messages: List,
-        context_variables: dict = {},
+        context_variables: dict = None,
         model_override: str = None,
         debug: bool = False,
         max_turns: int = float("inf"),
@@ -141,7 +141,7 @@ class Swarm:
         # START BLOCK 1: this block is identical to a block in run(), possibly can be refactored
         #
         active_assistant = assistant
-        context_variables = copy.deepcopy(context_variables)
+        context_variables = copy.deepcopy(context_variables) if context_variables else {}
         history = copy.deepcopy(messages)
         init_len = len(messages)
         #
@@ -255,7 +255,7 @@ class Swarm:
         self,
         assistant: Assistant,
         messages: List,
-        context_variables: dict = {},
+        context_variables: dict = None,
         model_override: str = None,
         stream: bool = False,
         debug: bool = False,
@@ -277,7 +277,7 @@ class Swarm:
         # START BLOCK 1: this block is identical to a block in runAndStream(), possibly can be refactored
         #
         active_assistant = assistant
-        context_variables = copy.deepcopy(context_variables)
+        context_variables = copy.deepcopy(context_variables) if context_variables else {}
         history = copy.deepcopy(messages)
         init_len = len(messages)
         #

--- a/swarm/repl/repl.py
+++ b/swarm/repl/repl.py
@@ -59,12 +59,13 @@ def pretty_print_messages(messages) -> None:
 
 
 def run_demo_loop(
-    starting_assistant, context_variables={}, stream=False, debug=False
+    starting_assistant, context_variables=None, stream=False, debug=False
 ) -> None:
     client = Swarm()
     print("Starting Swarm CLI 🐝")
 
     messages = []
+    context_variables = context_variables or {}
     assistant = starting_assistant
 
     while True:

--- a/swarm/types.py
+++ b/swarm/types.py
@@ -1,10 +1,9 @@
-from openai.types.chat import ChatCompletionMessage
-from openai.types.chat.chat_completion_message_tool_call import (
-    ChatCompletionMessageToolCall,
-    Function,
+from typing import (
+    Callable,
+    List,
+    Optional,
+    Union,
 )
-
-from typing import List, Callable, Union, Optional
 
 # Third-party imports
 from pydantic import BaseModel


### PR DESCRIPTION
###### Why/Context/Summary

**NOTE: This is not fully fleshed out yet but the concept is shown.**

What this PR does is allows us to think of an `Assistant` as "someone who does work" but how the work gets done is not important -- all assistants can hand off control and participate in the message stream.

Refer to [this PR](https://github.com/openai/superassistant/pull/8516) for usage.

1) Added the ability to run a `post_execute` method on any assistant.  Changed the loop to have the concept of `next_assistant`.  The chat completions and tools run as usual, but if the `Assistant` has a `post_execute` method, it will always be called and has the ability to create a different handoff.

2) Added `ToolAssistant` which only runs tools.  This can be optimized but is not yet.

###### Test plan