### PR TITLE
Pin pre-commit hook revisions to immutable commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/hhatto/autopep8
-    rev: 0fa37c25a2a48abfbd18cdfac91985e21bdbf249
+    rev: 0fa37c25a2a48abfbd18cdfac91985e21bdbf249  # v2.1.0
     hooks:
       - id: autopep8
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/hhatto/autopep8
-    rev: v2.1.0
+    rev: 0fa37c25a2a48abfbd18cdfac91985e21bdbf249
     hooks:
       - id: autopep8
         args:


### PR DESCRIPTION
## What's changing
Replace non-commit `rev:` values in `.pre-commit-config.yaml` with the exact commit those refs resolve to today.

## Why
Tags and branch names can be retargeted upstream; pinning to immutable commits keeps the selected code the same over time.
