### PR TITLE
feat: add TWZRD agent trust checker example

### DIFF
--- a/examples/twzrd_trust/README.md
+++ b/examples/twzrd_trust/README.md
@@ -1,0 +1,56 @@
+# TWZRD Agent Trust Checker
+
+A Swarm example that gates agent requests behind on-chain Solana trust
+verification using the [TWZRD Agent Intel](https://intel.twzrd.xyz) MCP server.
+
+## What It Does
+
+Two cooperating agents:
+
+1. **Trust Checker** — calls the TWZRD MCP server to score a Solana wallet
+   and run a preflight check. Wallets with a trust score ≥ 0.5 and an
+   `APPROVE` preflight result are forwarded to the payment processor.
+2. **Payment Processor** — handles requests from verified agents only.
+
+## Setup
+
+```bash
+pip install swarm mcp openai
+export OPENAI_API_KEY=sk-...
+```
+
+The TWZRD MCP server requires no API key for `score_agent` and
+`preflight_check`. The `get_trust_receipt` tool is a paid endpoint
+(HTTP 402 / x402 protocol) — see [intel.twzrd.xyz](https://intel.twzrd.xyz).
+
+## MCP Config
+
+```json
+{
+  "mcpServers": {
+    "twzrd-agent-intel": {
+      "url": "https://intel.twzrd.xyz/mcp"
+    }
+  }
+}
+```
+
+## Run
+
+```shell
+python3 run.py
+```
+
+Then enter a prompt like:
+
+```
+Check wallet D1QkbFJKiPsymJ65RKHhF6DFB8sPMfpBaFBzuHKfJGWi
+```
+
+## Tools
+
+| Tool | Description | Cost |
+|------|-------------|------|
+| `score_agent` | Trust score (0–1) + x402 payment count | Free |
+| `preflight_check` | APPROVE/REJECT with reasoning | Free |
+| `get_trust_receipt` | Signed on-chain trust receipt | HTTP 402 |

--- a/examples/twzrd_trust/agents.py
+++ b/examples/twzrd_trust/agents.py
@@ -1,0 +1,84 @@
+"""
+TWZRD Agent Trust Checker - agents.py
+
+Demonstrates using TWZRD Agent Intel MCP server to verify Solana agent
+trustworthiness before processing requests. Agents with low trust scores
+or failed preflight checks are rejected.
+
+MCP server: https://intel.twzrd.xyz/mcp
+Tools: score_agent, preflight_check (free); get_trust_receipt (x402 paid)
+"""
+
+import asyncio
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+from swarm import Agent
+
+MCP_URL = "https://intel.twzrd.xyz/mcp"
+TRUST_THRESHOLD = 0.5
+
+
+async def _call_mcp_tool(tool_name: str, wallet: str) -> str:
+    """Call a TWZRD MCP tool and return the result text."""
+    async with streamablehttp_client(MCP_URL) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.call_tool(tool_name, {"wallet": wallet})
+            return result.content[0].text
+
+
+def score_agent_wallet(wallet: str) -> str:
+    """
+    Score a Solana agent wallet using TWZRD Agent Intel.
+    Returns trust score (0-1) and x402 payment history.
+    """
+    result = asyncio.run(_call_mcp_tool("score_agent", wallet))
+    return result
+
+
+def preflight_check_wallet(wallet: str) -> str:
+    """
+    Run a preflight check on a Solana agent wallet.
+    Returns APPROVE or REJECT with detailed reasoning.
+    """
+    result = asyncio.run(_call_mcp_tool("preflight_check", wallet))
+    return result
+
+
+def transfer_to_payment_processor():
+    """Transfer approved agents to the payment processing agent."""
+    return payment_agent
+
+
+def transfer_to_trust_checker():
+    """Route back to trust checker for re-verification."""
+    return trust_agent
+
+
+trust_agent = Agent(
+    name="Trust Checker",
+    instructions=(
+        "You verify Solana agent wallets before allowing them to proceed. "
+        "For every request: "
+        "1. Extract the wallet address from the user message. "
+        "2. Call score_agent_wallet to get the trust score. "
+        "3. Call preflight_check_wallet for a APPROVE/REJECT decision. "
+        f"4. If the preflight result is APPROVE and score >= {TRUST_THRESHOLD}: "
+        "   transfer to the payment_agent. "
+        "5. Otherwise: inform the user their wallet is not trusted and stop. "
+        "Always cite the trust score and preflight result in your response."
+    ),
+    functions=[score_agent_wallet, preflight_check_wallet, transfer_to_payment_processor],
+)
+
+payment_agent = Agent(
+    name="Payment Processor",
+    instructions=(
+        "You process requests from verified, trusted Solana agents. "
+        "The trust checker has already verified the agent wallet. "
+        "Acknowledge the verified agent and process their request. "
+        "If the user asks about their trust receipt, remind them they can call "
+        "get_trust_receipt via https://intel.twzrd.xyz/mcp (paid endpoint, HTTP 402)."
+    ),
+    functions=[transfer_to_trust_checker],
+)

--- a/examples/twzrd_trust/run.py
+++ b/examples/twzrd_trust/run.py
@@ -1,0 +1,12 @@
+"""run.py - Interactive TWZRD agent trust verification demo."""
+
+from swarm.repl import run_demo_loop
+from agents import trust_agent
+
+if __name__ == "__main__":
+    print("TWZRD Agent Trust Checker")
+    print("=" * 40)
+    print("Try: Check wallet D1QkbFJKiPsymJ65RKHhF6DFB8sPMfpBaFBzuHKfJGWi")
+    print("MCP server: https://intel.twzrd.xyz/mcp")
+    print()
+    run_demo_loop(trust_agent, stream=True)


### PR DESCRIPTION
## Summary

Adds `examples/twzrd_trust/` — a minimal Swarm example demonstrating how to gate agent requests behind on-chain Solana trust verification.

**What it shows:**
- Two cooperating agents: `Trust Checker` → `Payment Processor`
- `Trust Checker` calls the [TWZRD Agent Intel](https://intel.twzrd.xyz) MCP server (streamable-HTTP) to score a Solana wallet and run a preflight check before allowing the request to proceed
- Wallets with trust score ≥ 0.5 and `APPROVE` preflight are forwarded; others are rejected

**MCP server details:**
- Endpoint: `https://intel.twzrd.xyz/mcp` (streamable-HTTP, no API key needed)
- Free tools: `score_agent(wallet)`, `preflight_check(wallet)`
- Paid tool: `get_trust_receipt(wallet)` (HTTP 402 / x402)

**Files added:**
- `examples/twzrd_trust/agents.py` — agent definitions with MCP tool wrappers
- `examples/twzrd_trust/run.py` — interactive REPL entry point
- `examples/twzrd_trust/README.md` — setup and usage instructions

Follows the same `agents.py` + `run.py` + `README.md` structure as `triage_agent` and `weather_agent`.